### PR TITLE
Add round counter display to interval timer mode

### DIFF
--- a/app/features/timer/components/TimerDisplay.ts
+++ b/app/features/timer/components/TimerDisplay.ts
@@ -100,6 +100,13 @@ export class TimerDisplay {
       cls: "workout-timer-time-display",
       text: displayTime,
     });
+
+    if (state.timerType === TIMER_TYPE.INTERVAL) {
+      state.timerDisplay.createEl("span", {
+        cls: "workout-timer-round-counter",
+        text: `${state.currentRound} / ${state.totalRounds}`,
+      });
+    }
   }
 
   static createDisplay(container: HTMLElement): HTMLElement {

--- a/app/styles/_timer.scss
+++ b/app/styles/_timer.scss
@@ -61,6 +61,7 @@
   border: var(--workout-border-thin) solid var(--background-modifier-border);
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: var(--workout-space-lg);
   font-size: var(--workout-font-xl);
   flex: 1;

--- a/app/styles/_timer.scss
+++ b/app/styles/_timer.scss
@@ -69,6 +69,8 @@
   .workout-timer-time {
     display: flex;
     align-items: center;
+    flex-direction: column;
+    gap: var(--workout-space-2xs, 2px);
 
     .workout-timer-time-display {
       font-size: var(--workout-font-xl);
@@ -77,6 +79,14 @@
       font-family: monospace;
       min-width: var(--workout-size-3xl);
       text-align: center;
+    }
+
+    .workout-timer-round-counter {
+      font-size: var(--workout-font-sm);
+      color: var(--text-muted);
+      font-family: monospace;
+      text-align: center;
+      letter-spacing: 0.04em;
     }
 
     .workout-timer-complete {

--- a/app/styles/utilities/_log.scss
+++ b/app/styles/utilities/_log.scss
@@ -21,5 +21,6 @@
   }
   .workout-buttons-container {
     justify-content: center;
+    flex-wrap: wrap;
   }
 }


### PR DESCRIPTION
Shows current round progress (e.g. "2 / 5") below the time display
when the timer is in interval mode.

https://claude.ai/code/session_01ELs5JzKM8bVUKAnAfcFjCK